### PR TITLE
improve(@sinoui/sinoui-components-library): 优化Field二次render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v1.0.0-alpha.5
 
 - fix(@sinoui/rx-form-state): useFomrSelect -> useFormSelect
+- improve(@sinoui/sinoui-components-forms): 优化 Field 初始化时的二次渲染
 
 ## v1.0.0-alpha.4 (2019.8.12)
 

--- a/packages/sinoui-components-forms/package.json
+++ b/packages/sinoui-components-forms/package.json
@@ -25,6 +25,8 @@
     "classnames": "^2.2.6",
     "immer": "^3.2.0",
     "lodash": "^4.17.15",
+    "rxjs": "^6.5.2",
+    "shallowequal": "^1.1.0",
     "sinoui-components": "^0.1.27"
   },
   "peerDependencies": {

--- a/packages/sinoui-components-forms/src/FormItem/FormItem.tsx
+++ b/packages/sinoui-components-forms/src/FormItem/FormItem.tsx
@@ -73,25 +73,15 @@ function getLabel(children: React.ReactNode) {
 /**
  * 渲染标签
  */
-function renderLabel(
-  label: React.ReactNode,
-  children: React.ReactNode,
-  name?: string,
-) {
+function renderLabel(label: React.ReactNode, children: React.ReactNode) {
   if (label && typeof label === 'string') {
-    return <Label name={name}>{label}</Label>;
+    return <Label>{label}</Label>;
   }
   if (label) {
-    return React.cloneElement(label as any, { name });
+    return label;
   }
 
-  const child = getLabel(children);
-
-  if (child) {
-    return React.cloneElement(child as any, { name });
-  }
-
-  return child;
+  return getLabel(children);
 }
 
 /**
@@ -100,31 +90,28 @@ function renderLabel(
 function FormItem(props: Props) {
   const {
     label,
-    disabled: disabledProp,
-    readOnly: readOnlyProp,
-    inline: inlineProp,
-    vertical: verticalProp,
-    name: nameProp,
+    disabled,
+    readOnly,
+    inline,
+    vertical,
+    name,
     children,
     className,
     style,
     contentStyle,
   } = props;
 
-  const context = useFormItemState(nameProp, {
-    inlineProp,
-    verticalProp,
-    readOnlyProp,
-    disabledProp,
+  const context = useFormItemState({
+    name,
+    inline,
+    vertical,
+    readOnly,
+    disabled,
   });
-  const { fields, inline, vertical } = context;
 
-  const name = nameProp || (fields.length > 0 ? fields[0].name : undefined);
-
-  const newLabel = useMemo(() => renderLabel(label, children, name), [
+  const newLabel = useMemo(() => renderLabel(label, children), [
     children,
     label,
-    name,
   ]);
 
   return (

--- a/packages/sinoui-components-forms/src/FormItem/FormItemContext.ts
+++ b/packages/sinoui-components-forms/src/FormItem/FormItemContext.ts
@@ -1,19 +1,10 @@
 import React from 'react';
-import { FieldConfig, FieldValidateProps } from '@sinoui/rx-form-state/src';
+import { FormItemContextModel } from './types';
 
-export interface FormItemState {
-  id: number;
-  name?: string;
-  fields: (Partial<FieldConfig> & FieldValidateProps)[];
-  addField: (field: Partial<FieldConfig> & FieldValidateProps) => void;
-  removeField: (fieldName: string) => void;
-  inline?: boolean;
-  vertical?: boolean;
-  readOnly?: boolean;
-  disabled?: boolean;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const FormItemContext = React.createContext<FormItemState>({} as any);
+const FormItemContext = React.createContext<FormItemContextModel>({
+  useFormItem: () => ({}),
+  useFormItemProps: () => ({}),
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+} as any);
 
 export default FormItemContext;

--- a/packages/sinoui-components-forms/src/FormItem/FormItemError.tsx
+++ b/packages/sinoui-components-forms/src/FormItem/FormItemError.tsx
@@ -13,13 +13,9 @@ const FormItemErrorWrapper = styled.div`
  * 渲染表单域错误信息
  */
 function FormItemError() {
-  const { name, fields } = useContext(FormItemContext);
-  const fieldName = useMemo(
-    () => name || (fields.length > 0 ? fields[0].name : undefined),
-    [name, fields],
-  );
-  const error = useFieldError(fieldName);
-  const isTouched = useFieldTouched(fieldName);
+  const { name } = useContext(FormItemContext).useFormItem();
+  const error = useFieldError(name);
+  const isTouched = useFieldTouched(name);
 
   return error && isTouched ? (
     <FormItemErrorWrapper

--- a/packages/sinoui-components-forms/src/FormItem/createFormItemContext.test.ts
+++ b/packages/sinoui-components-forms/src/FormItem/createFormItemContext.test.ts
@@ -1,0 +1,110 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { act } from '@testing-library/react';
+import createFormItemContext from './createFormItemContext';
+
+it('创建表单项上下文', () => {
+  const formItemContext = createFormItemContext({
+    fields: [],
+    id: 1,
+    readOnly: false,
+    inline: true,
+    vertical: false,
+  });
+
+  const { result } = renderHook(() => formItemContext.useFormItem());
+
+  expect(result.current.readOnly).toBe(false);
+  expect(result.current.inline).toBe(true);
+  expect(result.current.vertical).toBe(false);
+
+  act(() => {
+    formItemContext.addField({
+      name: 'userName',
+      disabled: true,
+      readOnly: true,
+      required: true,
+    });
+  });
+
+  expect(result.current.name).toBe('userName');
+  expect(result.current.disabled).toBe(true);
+  expect(result.current.readOnly).toBe(false);
+  expect(result.current.required).toBe(true);
+
+  act(() => {
+    formItemContext.setFormItemProps({
+      name: 'firstName',
+      disabled: false,
+      readOnly: true,
+    });
+  });
+
+  expect(result.current.name).toBe('firstName');
+  expect(result.current.disabled).toBe(false);
+  expect(result.current.readOnly).toBe(true);
+});
+
+it('重复添加表单域', () => {
+  const formItemContext = createFormItemContext();
+
+  const { result } = renderHook(() => formItemContext.useFormItem());
+
+  act(() => {
+    formItemContext.addField({
+      name: 'userName',
+      readOnly: true,
+    });
+
+    formItemContext.addField({
+      name: 'userName',
+      disabled: true,
+    });
+  });
+
+  expect(result.current.name).toBe('userName');
+  expect(result.current.disabled).toBe(true);
+  expect(result.current.readOnly).toBe(undefined);
+});
+
+it('移除表单域', () => {
+  const formItemContext = createFormItemContext({
+    id: 1,
+    fields: [
+      {
+        name: 'userName',
+      },
+    ],
+  });
+
+  const { result } = renderHook(() => formItemContext.useFormItem());
+
+  act(() => {
+    formItemContext.removeField('userName');
+  });
+
+  expect(result.current.name).toBe(undefined);
+
+  // 删除不存在的表单域，不会导致程序崩溃
+  act(() => {
+    formItemContext.removeField('userName');
+  });
+});
+
+it('获取表单项属性', () => {
+  const formItemContext = createFormItemContext({
+    fields: [],
+    id: 1,
+    readOnly: false,
+    inline: true,
+    vertical: false,
+  });
+
+  const { result } = renderHook(() => formItemContext.useFormItemProps());
+
+  expect(result.current).toEqual({
+    id: 1,
+    readOnly: false,
+    inline: true,
+    vertical: false,
+  });
+});

--- a/packages/sinoui-components-forms/src/FormItem/createFormItemContext.ts
+++ b/packages/sinoui-components-forms/src/FormItem/createFormItemContext.ts
@@ -1,0 +1,120 @@
+import { BehaviorSubject } from 'rxjs';
+import { produce } from 'immer';
+import { useBehaviorSubject } from '@sinoui/rx-form-state';
+import {
+  FormItemStateModel,
+  FieldConfig,
+  FormItemContextStateModel,
+} from './types';
+
+/**
+ * 创建表单项上下文
+ *
+ * @param initialState 初始状态
+ */
+export default function createFormItemContext(
+  initialState: FormItemStateModel = { fields: [], id: 0 },
+) {
+  const state$ = new BehaviorSubject(initialState);
+
+  /**
+   * 设置表单项属性
+   *
+   * @param {FormItemStateModel} formItemProps 表单项属性
+   */
+  function setFormItemProps(
+    formItemProps: Omit<FormItemStateModel, 'fields' | 'id'>,
+  ) {
+    state$.next({
+      ...state$.value,
+      ...formItemProps,
+    });
+  }
+
+  /**
+   * 添加表单域配置
+   *
+   * @param fieldConfig 表单域配置
+   */
+  const addField = (fieldConfig: FieldConfig) => {
+    state$.next(
+      produce(state$.value, (draft) => {
+        const idx = draft.fields.findIndex(
+          (item) => item.name === fieldConfig.name,
+        );
+        if (idx === -1) {
+          draft.fields.push(fieldConfig);
+        } else {
+          draft.fields.splice(idx, 1, fieldConfig);
+        }
+      }),
+    );
+  };
+
+  /**
+   * 移除表单域
+   *
+   * @param name 表单域名称
+   */
+  const removeField = (name: string) => {
+    state$.next(
+      produce(state$.value, (draft) => {
+        const idx = draft.fields.findIndex((item) => item.name === name);
+
+        if (idx !== -1) {
+          draft.fields.splice(idx, 1);
+        }
+      }),
+    );
+  };
+
+  /**
+   * 获取表单项状态
+   */
+  const getState = (): FormItemContextStateModel => {
+    const { fields, ...rest } = state$.value;
+    const field = fields[0];
+
+    if (field) {
+      const name = rest.name || field.name;
+      const readOnly =
+        typeof rest.readOnly === 'boolean' ? rest.readOnly : field.readOnly;
+      const disabled =
+        typeof rest.disabled === 'boolean' ? rest.disabled : field.disabled;
+      return {
+        ...rest,
+        name,
+        readOnly,
+        disabled,
+        required: field.required,
+      };
+    }
+
+    return rest;
+  };
+
+  /**
+   * 获取表单项上下文状态的hook
+   */
+  const useFormItem = () => {
+    return useBehaviorSubject(state$, getState);
+  };
+
+  const getFormItemProps = () => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { fields, ...rest } = state$.value;
+    return rest;
+  };
+
+  const useFormItemProps = () => {
+    return useBehaviorSubject(state$, getFormItemProps);
+  };
+
+  return {
+    setFormItemProps,
+    addField,
+    removeField,
+    useFormItem,
+    useFormItemProps,
+  };
+}

--- a/packages/sinoui-components-forms/src/FormItem/types.ts
+++ b/packages/sinoui-components-forms/src/FormItem/types.ts
@@ -1,0 +1,45 @@
+/**
+ * 表单域配置
+ */
+export interface FieldConfig {
+  name?: string;
+  required?: boolean;
+  readOnly?: boolean;
+  disabled?: boolean;
+}
+
+/**
+ * 表单项状态模型
+ */
+export interface FormItemStateModel {
+  fields: FieldConfig[];
+  id: number;
+  name?: string;
+  inline?: boolean;
+  vertical?: boolean;
+  readOnly?: boolean;
+  disabled?: boolean;
+}
+
+/**
+ * 表单项上下文状态模型
+ */
+export interface FormItemContextStateModel {
+  id: number;
+  name?: string;
+  readOnly?: boolean;
+  disabled?: boolean;
+  inline?: boolean;
+  vertical?: boolean;
+  required?: boolean;
+}
+
+export interface FormItemContextModel {
+  addField: (fieldConfig: FieldConfig) => void;
+  removeField: (name: string) => void;
+  setFormItemProps: (
+    formItemProps: Omit<FormItemStateModel, 'id' | 'fields'>,
+  ) => void;
+  useFormItem: () => FormItemContextStateModel;
+  useFormItemProps: () => Omit<FormItemStateModel, 'fields'>;
+}

--- a/packages/sinoui-components-forms/src/FormItem/useFormItemState.ts
+++ b/packages/sinoui-components-forms/src/FormItem/useFormItemState.ts
@@ -1,137 +1,48 @@
 /* eslint-disable import/no-unresolved */
-import {
-  useMemo,
-  useCallback,
-  useState,
-  useRef,
-  useEffect,
-  useContext,
-} from 'react';
-import { FieldConfig, FieldValidateProps } from '@sinoui/rx-form-state';
-import { produce } from 'immer';
+import { useMemo, useRef, useContext } from 'react';
+import shallowEqual from 'shallowequal';
 import useId from './useId';
+import createFormItemContext from './createFormItemContext';
 import SinouiFormStateContext from '../SinouiFormStateContext';
 
 interface Options {
-  inlineProp?: boolean;
-  verticalProp?: boolean;
-  readOnlyProp?: boolean;
-  disabledProp?: boolean;
-}
-
-/**
- * 获取状态
- * @param fields 表单域
- * @param path 获取状态名称
- */
-function getState(
-  fields: (Partial<FieldConfig> &
-    FieldValidateProps & { readOnly?: boolean; disabled?: boolean })[],
-  path: 'required' | 'readOnly' | 'disabled',
-) {
-  return fields.length > 0 && fields[0][path];
+  name?: string;
+  inline?: boolean;
+  vertical?: boolean;
+  readOnly?: boolean;
+  disabled?: boolean;
 }
 
 /**
  * 处理表单域的hook
  * @param name 表单域名称
  */
-function useFormItemState(name: string | undefined, options?: Options) {
-  const id = useId();
-  const [fields, setFields] = useState<
-    (Partial<FieldConfig> & FieldValidateProps)[]
-  >([]);
-
-  const optionsRef = useRef(options);
-
-  useEffect(() => {
-    optionsRef.current = options;
-  }, [options]);
-
-  /**
-   * 新增表单域
-   *
-   * @param {Partial<FieldConfig> & FieldValidateProps} field 表单域
-   * @returns
-   */
-  const addField = useCallback(
-    (field: Partial<FieldConfig> & FieldValidateProps) => {
-      setFields(
-        produce((draft: (Partial<FieldConfig> & FieldValidateProps)[]) => {
-          const idx = draft.findIndex((item) => item.name === field.name);
-          if (idx === -1) {
-            draft.push(field);
-          } else {
-            draft.splice(idx, 1, field);
-          }
-        }),
-      );
-    },
-    [],
-  );
-
-  /**
-   * 删除表单域
-   *
-   * @param {string} fieldName 表单域名称
-   * @returns
-   */
-  const removeField = useCallback((fieldName) => {
-    setFields(
-      produce((draft: (Partial<FieldConfig> & FieldValidateProps)[]) => {
-        const idx = draft.findIndex((field) => field.name === fieldName);
-        if (idx !== -1) {
-          draft.splice(idx, 1);
-        }
-      }),
-    );
-  }, []);
-  const { inlineProp, verticalProp, readOnlyProp, disabledProp } =
+function useFormItemState(options: Options = {}) {
+  const { inline = options.inline, vertical = options.vertical } =
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    optionsRef.current || ({} as any);
-  const sinouiFormState = useContext(SinouiFormStateContext);
-
-  const inline =
-    typeof inlineProp === 'boolean'
-      ? inlineProp
-      : sinouiFormState && sinouiFormState.inline;
-  const vertical =
-    typeof verticalProp === 'boolean'
-      ? verticalProp
-      : sinouiFormState && sinouiFormState.vertical;
-  const readOnly =
-    typeof readOnlyProp === 'boolean'
-      ? readOnlyProp
-      : getState(fields, 'readOnly');
-  const disabled =
-    typeof disabledProp === 'boolean'
-      ? disabledProp
-      : getState(fields, 'disabled');
+    useContext(SinouiFormStateContext) || ({} as any);
+  const id = useId();
+  const newOptions = {
+    ...options,
+    inline,
+    vertical,
+  };
+  const optionsRef = useRef(newOptions);
 
   const context = useMemo(
-    () => ({
-      id,
-      name,
-      fields,
-      addField,
-      removeField,
-      inline,
-      vertical,
-      readOnly,
-      disabled,
-    }),
-    [
-      id,
-      name,
-      fields,
-      addField,
-      removeField,
-      inline,
-      vertical,
-      readOnly,
-      disabled,
-    ],
+    () =>
+      createFormItemContext({
+        id,
+        fields: [],
+        ...optionsRef.current,
+      }),
+    [id],
   );
+
+  if (options && !shallowEqual(optionsRef.current, newOptions)) {
+    context.setFormItemProps(newOptions);
+    optionsRef.current = newOptions;
+  }
 
   return context;
 }

--- a/packages/sinoui-components-forms/src/Label.tsx
+++ b/packages/sinoui-components-forms/src/Label.tsx
@@ -53,12 +53,34 @@ function getLabelPropsFromSinouiFormContext(sinouiForm: SinouiFormState) {
 }
 
 /**
+ * 克隆对象的非undefined的属性
+ *
+ * @param object 对象
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function cloneObjectValue(object: any) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const newObj: any = {};
+  const keys = Object.keys(object);
+
+  keys.forEach((key) => {
+    if (object[key] !== undefined) {
+      newObj[key] = object[key];
+    }
+  });
+
+  return newObj;
+}
+
+/**
  * 表单项标签
  * @param props
  */
 const Label: React.SFC<LabelProps> = (props) => {
-  const formItemContext = useContext(FormItemContext).useFormItem();
-  const { name = formItemContext.name, className } = props;
+  const { name: nameFromFormItemContext, ...formItemProps } = useContext(
+    FormItemContext,
+  ).useFormItem();
+  const { name = nameFromFormItemContext, className } = props;
 
   const sinouiFormState = useContext(SinouiFormStateContext);
   const isValid = useFieldValid(name);
@@ -66,7 +88,7 @@ const Label: React.SFC<LabelProps> = (props) => {
 
   const labelProps = {
     ...getLabelPropsFromSinouiFormContext(sinouiFormState),
-    ...formItemContext,
+    ...formItemProps,
     ...props,
   };
 
@@ -76,7 +98,7 @@ const Label: React.SFC<LabelProps> = (props) => {
 
   return !inFormItemContent ? (
     <PureFormLabel
-      {...labelProps}
+      {...cloneObjectValue(labelProps)}
       className={classNames('sinoui-form-label', className)}
     />
   ) : null;

--- a/packages/sinoui-components-forms/src/Label.tsx
+++ b/packages/sinoui-components-forms/src/Label.tsx
@@ -1,10 +1,9 @@
 /* eslint-disable import/no-unresolved */
 import React, { useContext } from 'react';
 import FormLabel from 'sinoui-components/Form/FormControl/FormLabel';
-import { FieldValidateProps } from '@sinoui/rx-form-state';
 import classNames from 'classnames';
 import FormItemContentContext from './FormItem/FormItemContentContext';
-import FormItemContext, { FormItemState } from './FormItem/FormItemContext';
+import FormItemContext from './FormItem/FormItemContext';
 import useFieldValid from './useFieldValid';
 import SinouiFormStateContext, {
   SinouiFormState,
@@ -41,13 +40,6 @@ export interface LabelProps {
 }
 
 /**
- * 判断是否包含有必填校验的field
- */
-function containsRequired(fields: FieldValidateProps[]) {
-  return fields.length > 0 && !!fields[0].required;
-}
-
-/**
  * 从表单上下文中获取标签属性
  */
 function getLabelPropsFromSinouiFormContext(sinouiForm: SinouiFormState) {
@@ -61,42 +53,20 @@ function getLabelPropsFromSinouiFormContext(sinouiForm: SinouiFormState) {
 }
 
 /**
- * 从表单项上下文中获取标签属性
- */
-function getLabelPropsFromFormItemContext({
-  id,
-  fields = [],
-  inline,
-  vertical,
-  readOnly,
-  disabled,
-}: FormItemState) {
-  return {
-    vertical,
-    readOnly,
-    disabled,
-    inline,
-    htmlFor: `${id}`,
-    required: containsRequired(fields),
-  };
-}
-
-/**
  * 表单项标签
  * @param props
  */
 const Label: React.SFC<LabelProps> = (props) => {
-  const { name, className } = props;
+  const formItemContext = useContext(FormItemContext).useFormItem();
+  const { name = formItemContext.name, className } = props;
 
   const sinouiFormState = useContext(SinouiFormStateContext);
   const isValid = useFieldValid(name);
   const { inFormItemContent } = useContext(FormItemContentContext);
 
-  const formItemContext = useContext(FormItemContext);
-
   const labelProps = {
     ...getLabelPropsFromSinouiFormContext(sinouiFormState),
-    ...getLabelPropsFromFormItemContext(formItemContext),
+    ...formItemContext,
     ...props,
   };
 

--- a/packages/sinoui-components-forms/src/__tests__/FormItemError.test.tsx
+++ b/packages/sinoui-components-forms/src/__tests__/FormItemError.test.tsx
@@ -7,18 +7,16 @@ import FormItemError from '../FormItem/FormItemError';
 import FormItemContext from '../FormItem/FormItemContext';
 import Wrapper from './FormTestWrapper';
 import Field from '../Field';
-
-const context = {
-  id: 1,
-  name: 'userName',
-  fields: [{ name: 'userName', required: true }, { name: 'password' }],
-  addField: jest.fn(),
-  removeField: jest.fn(),
-};
+import createFormItemContext from '../FormItem/createFormItemContext';
 
 afterEach(cleanup);
 
 it('校验没有错误时，不渲染', () => {
+  const context = createFormItemContext({
+    id: 1,
+    name: 'userName',
+    fields: [],
+  });
   const { queryByTestId } = render(
     <Wrapper>
       <FormItemContext.Provider value={context}>
@@ -31,11 +29,14 @@ it('校验没有错误时，不渲染', () => {
 });
 
 it('校验错误出错，但touched状态为false时，不渲染', () => {
+  const context = createFormItemContext({
+    id: 1,
+    name: 'userName',
+    fields: [],
+  });
   const { queryByTestId, getByTestId } = render(
     <Wrapper>
-      <FormItemContext.Provider
-        value={{ ...context, name: 'userName', fields: [] }}
-      >
+      <FormItemContext.Provider value={context}>
         <Field as="input" name="userName" required data-testid="field" />
         <FormItemError />
       </FormItemContext.Provider>
@@ -52,9 +53,14 @@ it('校验错误出错，但touched状态为false时，不渲染', () => {
 });
 
 it('校验出错，并且touched为true时，渲染组件', () => {
+  const context = createFormItemContext({
+    id: 1,
+    name: 'userName',
+    fields: [],
+  });
   const { getByTestId } = render(
     <Wrapper>
-      <FormItemContext.Provider value={{ ...context, name: 'userName' }}>
+      <FormItemContext.Provider value={context}>
         <Field as="input" name="userName" required data-testid="field" />
         <FormItemError />
       </FormItemContext.Provider>

--- a/packages/sinoui-components-forms/src/__tests__/Label.test.tsx
+++ b/packages/sinoui-components-forms/src/__tests__/Label.test.tsx
@@ -4,16 +4,9 @@ import '@testing-library/jest-dom/extend-expect';
 import Label from '../Label';
 import Wrapper from './FormTestWrapper';
 import FormItemContext from '../FormItem/FormItemContext';
+import createFormItemContext from '../FormItem/createFormItemContext';
 
 afterEach(cleanup);
-
-const context = {
-  id: 1,
-  name: 'userName',
-  fields: [{ name: 'userName', required: true }],
-  addField: jest.fn(),
-  removeField: jest.fn(),
-};
 
 it('渲染Label', () => {
   const { getByText } = render(
@@ -26,6 +19,11 @@ it('渲染Label', () => {
 });
 
 it('如果第一个field存在必填校验，则Label会有必填样式', () => {
+  const context = createFormItemContext({
+    id: 1,
+    fields: [{ name: 'userName', required: true }],
+  });
+
   const { getByText } = render(
     <Wrapper>
       <FormItemContext.Provider value={context}>
@@ -38,16 +36,14 @@ it('如果第一个field存在必填校验，则Label会有必填样式', () => 
 });
 
 it('包含多个表单域时，第一个field没有required属性时，Label没有required属性', () => {
-  const newContext = {
+  const context = createFormItemContext({
     id: 1,
     name: 'userName',
     fields: [{ name: 'userName' }, { name: 'password', required: true }],
-    addField: jest.fn(),
-    removeField: jest.fn(),
-  };
+  });
   const { getByText } = render(
     <Wrapper>
-      <FormItemContext.Provider value={newContext}>
+      <FormItemContext.Provider value={context}>
         <Label>用户名</Label>
       </FormItemContext.Provider>
     </Wrapper>,
@@ -57,6 +53,11 @@ it('包含多个表单域时，第一个field没有required属性时，Label没�
 });
 
 it('如果label属性指定了htmlFor属性，则采用label元素的for应为htmlFor指定的值', () => {
+  const context = createFormItemContext({
+    id: 1,
+    fields: [{ name: 'userName', required: true }],
+  });
+  
   const { container } = render(
     <Wrapper>
       <FormItemContext.Provider value={context}>

--- a/packages/sinoui-components-forms/src/__tests__/Label.test.tsx
+++ b/packages/sinoui-components-forms/src/__tests__/Label.test.tsx
@@ -5,6 +5,8 @@ import Label from '../Label';
 import Wrapper from './FormTestWrapper';
 import FormItemContext from '../FormItem/FormItemContext';
 import createFormItemContext from '../FormItem/createFormItemContext';
+import Field from '../Field';
+import FormItem from '../FormItem/FormItem';
 
 afterEach(cleanup);
 
@@ -57,7 +59,7 @@ it('如果label属性指定了htmlFor属性，则采用label元素的for应为ht
     id: 1,
     fields: [{ name: 'userName', required: true }],
   });
-  
+
   const { container } = render(
     <Wrapper>
       <FormItemContext.Provider value={context}>
@@ -67,4 +69,25 @@ it('如果label属性指定了htmlFor属性，则采用label元素的for应为ht
   );
 
   expect(container.querySelector('label')).toHaveAttribute('for', '123');
+});
+
+it('避免PureLabel二次渲染', () => {
+  let count = 0;
+  function Child() {
+    count += 1;
+    return null;
+  }
+
+  render(
+    <Wrapper>
+      <FormItem>
+        <Label>
+          <Child />
+        </Label>
+        <Field name="test" as="input" />
+      </FormItem>
+    </Wrapper>,
+  );
+
+  expect(count).toBe(1);
 });

--- a/packages/sinoui-components-forms/src/__tests__/useFormItemState.test.tsx
+++ b/packages/sinoui-components-forms/src/__tests__/useFormItemState.test.tsx
@@ -1,73 +1,37 @@
-import React, { useEffect } from 'react';
-import { renderHook } from '@testing-library/react-hooks';
-import { render } from '@testing-library/react';
+import React from 'react';
+import { renderHook, act } from '@testing-library/react-hooks';
 import useFormItemState from '../FormItem/useFormItemState';
+import SinouiFormStateContext from '../SinouiFormStateContext';
 
 it('formItemState被定义', () => {
-  const { result } = renderHook(() => useFormItemState('userName'));
+  const { result, rerender } = renderHook((name: string = 'userName') =>
+    useFormItemState({ name }).useFormItem(),
+  );
 
   expect(result.current).toHaveProperty('id', 1);
   expect(result.current).toHaveProperty('name', 'userName');
+
+  // 更新配置
+  act(() => {
+    rerender('firstName');
+  });
+
+  expect(result.current.name).toBe('firstName');
 });
 
-it('添加Field', () => {
-  const { result } = renderHook(() => useFormItemState('userName'));
-
-  result.current.addField({ name: 'password' });
-  expect(result.current.fields).toEqual([{ name: 'password' }]);
-  expect(result.current.fields.length).toBe(1);
-
-  result.current.addField({ name: 'password' });
-  expect(result.current.fields.length).toBe(1);
-});
-
-it('删除Field', () => {
-  const { result } = renderHook(() => useFormItemState('userName'));
-
-  result.current.addField({ name: 'password' });
-  result.current.removeField('fav');
-
-  expect(result.current.fields.length).toBe(1);
-
-  result.current.removeField('password');
-
-  expect(result.current.fields.length).toBe(0);
-});
-
-it('配置项', () => {
-  const { result } = renderHook(() =>
-    useFormItemState('userName', {
-      inlineProp: true,
-      verticalProp: false,
-      readOnlyProp: true,
-    }),
-  );
-
-  expect(result.current.inline).toBeTruthy();
-  expect(result.current.vertical).toBeFalsy();
-  expect(result.current.readOnly).toBeTruthy();
-});
-
-it('循环渲染的问题', () => {
-  let count = 0;
-  function Wrapper() {
-    const { addField, removeField } = useFormItemState('userName', {
-      readOnlyProp: false,
-    });
-
-    useEffect(() => {
-      addField({ name: 'userName' });
-      return () => {
-        removeField('userName');
-      };
-    }, [addField, removeField]);
-
-    count += 1;
-
-    return null;
+it('从表单上下文中获取布局元素', () => {
+  function Wrapper({ children }: { children?: React.ReactNode }) {
+    const context = { inline: true, vertical: false, colon: false };
+    return (
+      <SinouiFormStateContext.Provider value={context}>
+        {children}
+      </SinouiFormStateContext.Provider>
+    );
   }
+  const { result } = renderHook(() => useFormItemState().useFormItem(), {
+    wrapper: Wrapper,
+  });
 
-  render(<Wrapper />);
-
-  expect(count).toBe(2);
+  expect(result.current.inline).toBe(true);
+  expect(result.current.vertical).toBe(false);
 });


### PR DESCRIPTION
FormItem收集Field的配置的目的：给Label组件应用上第一个Field的name、readOnly、disabled、required。

思路：因为Field只需要影响到Label即可。也就是说，FormItem需要给Field和Label之间建立一个沟通的桥梁（bridge），我们要求bridge存储最新的field，还要能广播最新的field配置变化。

采用RxJS的BehaviorSubject作为bridge。

但是这个方案会引起FormItem中的Label组件二次commit。但是Label组件非常轻量，二次commit也不会引起多大的性能消耗。与将状态存储在FormItem中的方案（方案二）相比：

|        | 优点                                           | 缺点                                     |
| ------ | ---------------------------------------------- | ---------------------------------------- |
| 方案一 | 避免了 FormItem、Field 的二次 render 和 commit | Label 依然会二次 render 和 commit        |
| 方案二 | 避免了 FormItem、Field 和 Label 的二次 commit  | FormItem、Field、Label 依然会二次 render |

在初始化Label的二次渲染不会引起DOM变化，所以，实际性能上还是非常好的。